### PR TITLE
Prevent issues with quotes in the action name or description

### DIFF
--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -23,9 +23,13 @@ jobs:
 
     - shell: bash
       name: Store json file
-      run: |
-        values=${{ steps.load-actions.outputs.actions }}
-        echo $values > 'actions-data.json'
+      run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
+      
+    - uses: github/action-script@v5
+      with:
+        script: |
+          let actions = `${{ steps.load-actions.outputs.actions }}`
+          echo $actions > 'actions-data2.json'
           
     - name: Upload result file as artefact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -27,7 +27,7 @@ jobs:
       name: Store json file
       run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
       
-    - uses: github/action-script@v5
+    - uses: actions/github-script@v5
       with:
         script: |
           let actions = `${{ steps.load-actions.outputs.actions }}`

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -1,3 +1,5 @@
+name: Get available action data
+
 on: 
   push:
     branches:

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -25,7 +25,7 @@ jobs:
 
     - shell: bash
       name: Store json file
-      if: never()
+      if: 1 == 2
       run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
       
     - uses: actions/github-script@v5

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -22,20 +22,13 @@ jobs:
       with: 
         PAT: ${{ secrets.PAT }}
         user: ${{ github.repository_owner }}
-
-    - shell: bash
-      name: Store json file
-      if: 1 == 2
-      run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
-      
-    - run: npm install fs
-    
+         
+    # todo: convert this part into an action to make it more transferable. Don't forget to update the readme then!
+    - run: npm install fs    
     - uses: actions/github-script@v5
       with:
         script: |
           let actions = `${{ steps.load-actions.outputs.actions }}`
-
-          //todo: enable this:
           const fs = require("fs");
 
           const fileName = 'actions-data.json'

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -24,7 +24,8 @@ jobs:
     - shell: bash
       name: Store json file
       run: |
-        echo '${{ fromJSON(steps.load-actions.outputs.actions) }}' > 'actions-data.json'
+        values=${{ steps.load-actions.outputs.actions }}
+        echo $values > 'actions-data.json'
           
     - name: Upload result file as artefact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -25,6 +25,7 @@ jobs:
 
     - shell: bash
       name: Store json file
+      if: never()
       run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
       
     - uses: actions/github-script@v5

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -24,7 +24,7 @@ jobs:
     - shell: bash
       name: Store json file
       run: |
-        echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
+        echo '${{ fromJSON(steps.load-actions.outputs.actions) }}' > 'actions-data.json'
           
     - name: Upload result file as artefact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/get-action-data.yml
+++ b/.github/workflows/get-action-data.yml
@@ -28,11 +28,22 @@ jobs:
       if: 1 == 2
       run: echo '${{ steps.load-actions.outputs.actions }}' > 'actions-data.json'
       
+    - run: npm install fs
+    
     - uses: actions/github-script@v5
       with:
         script: |
           let actions = `${{ steps.load-actions.outputs.actions }}`
-          echo $actions > 'actions-data2.json'
+
+          //todo: enable this:
+          const fs = require("fs");
+
+          const fileName = 'actions-data.json'
+          fs.writeFileSync(fileName, actions, function(err) {
+            if(err) {
+              return console.log("error")
+            }
+          })          
           
     - name: Upload result file as artefact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Echoing out the values with bash will fail, so this change makes use of node variables and writes them to disk using `fs`.